### PR TITLE
Adding #if canImport(UIKit) conditionals to compile on cross-platform apps

### DIFF
--- a/Examples/MailComposeSheet.swift
+++ b/Examples/MailComposeSheet.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 public extension View {
     /// Presents a native mail compose interface using MFMailComposeViewController.
     ///
@@ -152,3 +153,4 @@ private class MailComposeViewCoordinator: NSObject, MFMailComposeViewControllerD
         dismiss()
     }
 }
+#endif

--- a/Examples/ShareSheet.swift
+++ b/Examples/ShareSheet.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import LinkPresentation
 import SwiftUI
 import UniformTypeIdentifiers
@@ -75,3 +76,4 @@ struct PhoneNumberShareSheet_Previews: PreviewProvider {
         PreviewView()
     }
 }
+#endif

--- a/Sources/SafariWebView/SafariWebView.swift
+++ b/Sources/SafariWebView/SafariWebView.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SafariServices
 import SwiftUI
 import UIViewControllerPresenting
@@ -156,3 +157,4 @@ extension Binding {
         )
     }
 }
+#endif

--- a/Sources/UIViewControllerPresenting/UIViewControllerPresenting.swift
+++ b/Sources/UIViewControllerPresenting/UIViewControllerPresenting.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SwiftUI
 
 /// A SwiftUI view that can be used to present an arbitrary UIKit view controller.
@@ -163,3 +164,4 @@ extension UIViewControllerPresenting where Coordinator == Void {
         )
     }
 }
+#endif

--- a/Sources/UIViewControllerPresenting/ViewPresenting.swift
+++ b/Sources/UIViewControllerPresenting/ViewPresenting.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import SwiftUI
 import UIKit
 
@@ -157,3 +158,4 @@ public extension SheetConfiguration {
     }
 }
 
+#endif


### PR DESCRIPTION
This pull request is a simple one, it wraps all of the code in `#if canImport(UIKit)`.

I'm working on a cross-platform app (iOS, iPadOS, and macOS), but the macOS app won't compile because this library exists. SPM doesn't do conditional compilation so the Mac app tries to compile this library, and since someone working on a true native Mac app wouldn't be using `UIViewController` and all of the other related classes, I felt it was safe to wrap all teh code in the conditional.

I tested it in my own app and it seems to work fine, but let me know if something needs to be adjusted.

Thanks a lot for the library, it's been of great use to me!